### PR TITLE
Add build circuit timeout fixups

### DIFF
--- a/test/test_circuit.py
+++ b/test/test_circuit.py
@@ -12,17 +12,21 @@ from txtorcon import Stream
 from txtorcon import TorControlProtocol
 from txtorcon import TorState
 from txtorcon import Router
+from txtorcon.router import hexIdFromHash
 from txtorcon.interface import IRouterContainer
 from txtorcon.interface import ICircuitListener
 from txtorcon.interface import ICircuitContainer
 from txtorcon.interface import CircuitListenerMixin
 from txtorcon.interface import ITorControlProtocol
 
+from mock import Mock
+
 
 class FakeTorController(object):
     implements(IRouterContainer, ICircuitListener, ICircuitContainer, ITorControlProtocol)
 
     post_bootstrap = defer.Deferred()
+    queue_command = Mock()
 
     def __init__(self):
         self.routers = {}
@@ -72,7 +76,8 @@ class FakeRouter:
 
     def __init__(self, hsh, nm):
         self.name = nm
-        self.hash = hsh
+        self.id_hash = hsh
+        self.id_hex = hexIdFromHash(self.id_hash)
         self.location = FakeLocation()
 
 examples = ['CIRC 365 LAUNCHED PURPOSE=GENERAL',
@@ -207,7 +212,7 @@ class CircuitTests(unittest.TestCase):
                 )
                 for (r, p) in zip(ex.split()[3].split(','), circuit.path):
                     d = r.split('=')[0]
-                    self.assertEqual(d, p.hash)
+                    self.assertEqual(d, p.id_hash)
 
     def test_extend_messages(self):
         tor = FakeTorController()

--- a/test/test_torstate.py
+++ b/test/test_torstate.py
@@ -1189,10 +1189,15 @@ s Fast Guard Running Stable Valid
         timeout = 10
         clock = task.Clock()
         d = build_timeout_circuit(self.state, clock, path, timeout, using_guards=True)
+        d.addCallback(self.circuit_callback)
 
         self.assertEqual(self.transport.value(), 'EXTENDCIRCUIT 0 0000000000000000000000000000000000000000,0000000000000000000000000000000000000001,0000000000000000000000000000000000000002\r\n')
         self.send('250 EXTENDED 1234')
+        # we can't just .send('650 CIRC 1234 BUILT') this because we
+        # didn't fully hook up the protocol to the state, e.g. via
+        # post_bootstrap etc.
+        self.state.circuits[1234].update(['1234', 'BUILT'])
         # should have gotten a warning about this not being an entry
         # guard
         self.assertEqual(len(self.flushWarnings()), 1)
-        return defer.succeed(None)
+        return d

--- a/txtorcon/circuit.py
+++ b/txtorcon/circuit.py
@@ -276,11 +276,13 @@ class Circuit(object):
         return "<Circuit %d %s [%s] for %s>" % (self.id, self.state, path,
                                                 self.purpose)
 
+
 class CircuitBuildTimedOutError(Exception):
     """
     This exception is thrown when using `timed_circuit_build`
     and the circuit build times-out.
     """
+
 
 def build_timeout_circuit(tor_state, reactor, path, timeout, using_guards=False):
     """
@@ -291,6 +293,7 @@ def build_timeout_circuit(tor_state, reactor, path, timeout, using_guards=False)
     """
     d = tor_state.build_circuit(path, using_guards)
     reactor.callLater(timeout, d.cancel)
+
     def trap_cancel(f):
         f.trap(defer.CancelledError)
         return Failure(CircuitBuildTimedOutError("circuit build timed out"))


### PR DESCRIPTION
What about this? Adds some flake8 whitespace fixes, more mocks so the "test_basics" passes and a different solution for the not_timeout test so that we "really" do the callback by getting the circuit to BUILT state.
